### PR TITLE
The https link to ionicframework.com doesn't work

### DIFF
--- a/layouts/default.haml
+++ b/layouts/default.haml
@@ -26,7 +26,7 @@
         %span.expand-wrapper
           %span.expand
         %nav#nav
-          %a{target: '_blank', href: "https://ionicframework.com"} Ionic
+          %a{target: '_blank', href: "http://ionicframework.com"} Ionic
           %a{target: '_blank', href: "https://github.com/driftyco/ionic"} Github
           %a{target: '_blank', href: "mailto:hi@ionicframework.com"} Contact us
           %a{target: '_blank', href: "https://github.com/driftyco/ionic-learn/issues/new"} Suggestions


### PR DESCRIPTION
Changed to the http variant. See #17
