### PR TITLE
fix Sass unable to compile to do unicode characters.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,3 +74,6 @@ DEPENDENCIES
   kramdown
   nanoc
   sass
+
+BUNDLED WITH
+   1.10.2

--- a/content/css/_fonts.scss
+++ b/content/css/_fonts.scss
@@ -18,7 +18,7 @@
  * Licensed pageviews: 250,000
  * Webfonts copyright: Copyright &#x00A9; 2004 - 2007 Linotype GmbH, www.linotype.com. All rights reserved. This font software may not be reproduced, modified, disclosed or transferred without the express written approval of Linotype GmbH. Avenir is a trademark of Linotype GmbH
  * 
- * © 2013 MyFonts Inc
+ * &#x00A9 2013 MyFonts Inc
 */
 
 

--- a/content/css/bootstrap/_grid.scss
+++ b/content/css/bootstrap/_grid.scss
@@ -76,7 +76,7 @@
 // Grid classes for extra small devices like smartphones. No offset, push, or
 // pull classes are present here due to the size of the target.
 //
-// Note that `.col-xs-12` doesn't get floated on purpose—there's no need since
+// Note that `.col-xs-12` doesn't get floated on purpose-there's no need since
 // it's full-width.
 
 .col-xs-1,
@@ -111,7 +111,7 @@
 // Columns, offsets, pushes, and pulls for the small device range, from phones
 // to tablets.
 //
-// Note that `.col-sm-12` doesn't get floated on purpose—there's no need since
+// Note that `.col-sm-12` doesn't get floated on purpose-there's no need since
 // it's full-width.
 
 @media (min-width: $screen-tablet) {
@@ -189,7 +189,7 @@
 //
 // Columns, offsets, pushes, and pulls for the desktop device range.
 //
-// Note that `.col-md-12` doesn't get floated on purpose—there's no need since
+// Note that `.col-md-12` doesn't get floated on purpose-there's no need since
 // it's full-width.
 
 @media (min-width: $screen-desktop) {
@@ -269,7 +269,7 @@
 //
 // Columns, offsets, pushes, and pulls for the large desktop device range.
 //
-// Note that `.col-lg-12` doesn't get floated on purpose—there's no need since
+// Note that `.col-lg-12` doesn't get floated on purpose-there's no need since
 // it's full-width.
 
 @media (min-width: $screen-lg-desktop) {


### PR DESCRIPTION
when trying to contribute to the project, one step is to compile sass; compiling throws three errors related to unicode characters; I changed those unicode characters to either the `-` equivalent, or used the Sass safe version of the character (in the case of the copyright sign).